### PR TITLE
Support agent worker pool size in helm chart

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)
@@ -40,4 +40,4 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install
+        run: ct install --target-branch ${{ github.event.repository.default_branch }}

--- a/charts/koala-agent/Chart.yaml
+++ b/charts/koala-agent/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.0.3"
+appVersion: "v1.0.4"
 
 maintainers:
   - name: nadaverell

--- a/charts/koala-agent/templates/clusterrole.yaml
+++ b/charts/koala-agent/templates/clusterrole.yaml
@@ -114,8 +114,9 @@ rules:
   - apiGroups:
     - external-secrets.io # External Secrets
     - monitoring.googleapis.com # Stackdriver / GCP Monitoring
-    - argoproj.io # Argo CD/Workflows/Events/Rollouts
     - monitoring.coreos.com # Prometheus
+    - monitoring.grafana.com # Grafana
+    - argoproj.io # Argo CD/Workflows/Events/Rollouts
     resources:
     - '*'
     verbs:

--- a/charts/koala-agent/templates/deployment.yaml
+++ b/charts/koala-agent/templates/deployment.yaml
@@ -64,6 +64,8 @@ spec:
                   name: {{ include "koala-agent.name" . }}-secret
                   {{- end }}
                   key: KOALA_API_KEY
+            - name: WORKER_POOL_SIZE
+              value: "{{ .Values.workerPoolSize | default 5 }}"
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/koala-agent/templates/tests/test-connection.yaml
+++ b/charts/koala-agent/templates/tests/test-connection.yaml
@@ -1,15 +1,69 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "koala-agent.fullname" . }}-test-connection"
-  labels:
-    {{- include "koala-agent.labels" . | nindent 4 }}
+  name: {{ .Release.Name }}-test-connection
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
 spec:
+  serviceAccountName: {{ .Release.Name }}-test-sa
+  initContainers:
+    - name: fetch-ip
+      image: bitnami/kubectl:latest
+      command:
+        - sh
+        - -c
+        - |
+          echo "Fetching Koala Agent Pod IP..."
+          kubectl get pod -n {{ .Release.Namespace }} -l app.kubernetes.io/name=koala-agent -o jsonpath='{.items[0].status.podIP}' > /tmp/koala-agent-ip
+      volumeMounts:
+        - name: shared-data
+          mountPath: /tmp
   containers:
     - name: wget
       image: busybox
-      command: ['wget']
-      args: ['{{ include "koala-agent.fullname" . }}:{{ .Values.service.port }}']
+      command:
+        - sh
+        - -c
+        - |
+          KOALA_AGENT_IP=$(cat /tmp/koala-agent-ip)
+          echo "Koala Agent IP: $KOALA_AGENT_IP"
+          wget --spider --timeout=5 http://$KOALA_AGENT_IP:8080 || exit 1
+      volumeMounts:
+        - name: shared-data
+          mountPath: /tmp
   restartPolicy: Never
+  volumes:
+    - name: shared-data
+      emptyDir: {}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-pod-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-read-pods-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-pod-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-test-sa
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-test-sa
+  namespace: {{ .Release.Namespace }}

--- a/charts/koala-agent/values.yaml
+++ b/charts/koala-agent/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: me-west1-docker.pkg.dev/koala-ops-demo-373407/koala-public/koala-agent
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v1.0.3"
+  tag: "v1.0.4"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -72,6 +72,12 @@ tolerations: [
 
 affinity: {}
 
+# Name of the secret to use for the API key. Keep empty to use the default secret name.
 existingSecret: ""
 
-apiKey: "aa"
+# Number of concurrent tasks to run.
+workerPoolSize: 5
+
+# API key to use for the agent (to be placed in the secret). Expected to be provided during 'helm install'.
+apiKey: "placeholder"
+

--- a/charts/koala-agent/values.yaml
+++ b/charts/koala-agent/values.yaml
@@ -23,6 +23,9 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   # name: ""
 
+labels:
+  app.kubernetes.io/name: koala-agent
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -80,4 +83,3 @@ workerPoolSize: 5
 
 # API key to use for the agent (to be placed in the secret). Expected to be provided during 'helm install'.
 apiKey: "placeholder"
-


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Adds support for configuring the agent worker pool size in the Helm chart. Updates the Koala Agent deployment to use the new <code>workerPoolSize</code> value, enhances the test connection pod with improved IP fetching, and updates RBAC permissions. Bumps the chart and app version to 1.0.4.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/KoalaOps/helm-charts/4?tool=ast&topic=Worker+Pool+Config>Worker Pool Config</a>
        </td><td>Adds support for configuring the agent worker pool size in the Helm chart and deployment<details><summary>Modified files (2)</summary><ul><li>charts/koala-agent/templates/deployment.yaml</li>
<li>charts/koala-agent/values.yaml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nadaverell</td><td>Bump-agent-helm-chart-...</td><td>June 05, 2024</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/KoalaOps/helm-charts/4?tool=ast&topic=Minor+Adjustments>Minor Adjustments</a>
        </td><td>Makes minor adjustments to RBAC permissions and CI workflow<details><summary>Modified files (2)</summary><ul><li>.github/workflows/lint-test.yml</li>
<li>charts/koala-agent/templates/clusterrole.yaml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>hisco</td><td>removed-redudent-steps</td><td>April 23, 2024</td></tr>
<tr><td>nadaverell</td><td>upgrade-actions-in-hel...</td><td>March 09, 2024</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/KoalaOps/helm-charts/4?tool=ast&topic=Version+Updates>Version Updates</a>
        </td><td>Updates chart and app version to 1.0.4<details><summary>Modified files (2)</summary><ul><li>charts/koala-agent/values.yaml</li>
<li>charts/koala-agent/Chart.yaml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nadaverell</td><td>Bump-agent-helm-chart-...</td><td>June 05, 2024</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/KoalaOps/helm-charts/4?tool=ast&topic=Test+Improvements>Test Improvements</a>
        </td><td>Enhances the test connection pod with improved IP fetching and RBAC permissions<details><summary>Modified files (1)</summary><ul><li>charts/koala-agent/templates/tests/test-connection.yaml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nadaverell</td><td>Initial-chart-for-koal...</td><td>February 07, 2023</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @nadaverell and the rest of your team on <a href=https://baz.co/changes/KoalaOps/helm-charts/4?tool=ast>(Baz)</a>.
    