### PR TITLE
Bump agent to 1.0.5

### DIFF
--- a/charts/koala-agent/Chart.yaml
+++ b/charts/koala-agent/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.0.4"
+appVersion: "v1.0.5"
 
 maintainers:
   - name: nadaverell

--- a/charts/koala-agent/values.yaml
+++ b/charts/koala-agent/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: me-west1-docker.pkg.dev/koala-ops-demo-373407/koala-public/koala-agent
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v1.0.4"
+  tag: "v1.0.5"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Updates the Koala agent version from 1.0.4 to 1.0.5 in the Helm chart files, including <code>Chart.yaml</code> and <code>values.yaml</code>.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/KoalaOps/helm-charts/5?tool=ast&topic=Version+Bump>Version Bump</a>
        </td><td>Increments the Koala agent version from 1.0.4 to 1.0.5 in Helm chart configuration files.<details><summary>Modified files (2)</summary><ul><li>charts/koala-agent/Chart.yaml</li>
<li>charts/koala-agent/values.yaml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nadaverell</td><td>Bump-agent-helm-chart-...</td><td>June 05, 2024</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @nadaverell and the rest of your team on <a href=https://baz.co/changes/KoalaOps/helm-charts/5?tool=ast>(Baz)</a>.
    