### PR TITLE
Bump agent to 1.0.6 and give it access to its pod name and namespace.

### DIFF
--- a/charts/koala-agent/Chart.yaml
+++ b/charts/koala-agent/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.0.5"
+appVersion: "v1.0.6"
 
 maintainers:
   - name: nadaverell

--- a/charts/koala-agent/templates/clusterrole.yaml
+++ b/charts/koala-agent/templates/clusterrole.yaml
@@ -10,11 +10,21 @@ rules:
   - apiGroups:
     - ""
     resources:
+    - namespaces
+    verbs:
+    - get
+    - watch
+    - list
+    # Required for automating deletion of ephemeral/preview environments. 
+    # Agent is hardcoded to only allow deleting namespaces prefixed with "preview-" or "ephemeral-".
+    - delete
+  - apiGroups:
+    - ""
+    resources:
     - events
     - pods
     - replicationcontrollers
     - services
-    - namespaces
     - configmaps
     - nodes
     - persistentvolumes

--- a/charts/koala-agent/templates/deployment.yaml
+++ b/charts/koala-agent/templates/deployment.yaml
@@ -64,6 +64,14 @@ spec:
                   name: {{ include "koala-agent.name" . }}-secret
                   {{- end }}
                   key: KOALA_API_KEY
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: WORKER_POOL_SIZE
               value: "{{ .Values.workerPoolSize | default 5 }}"
       {{- with .Values.nodeSelector }}

--- a/charts/koala-agent/values.yaml
+++ b/charts/koala-agent/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: me-west1-docker.pkg.dev/koala-ops-demo-373407/koala-public/koala-agent
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v1.0.5"
+  tag: "v1.0.6"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Updates the Koala agent to version 1.0.6, granting it access to its own pod name and namespace. Modifies the cluster role to allow the agent to manage namespaces, particularly for automating the deletion of ephemeral/preview environments. Adjusts the deployment template to include pod name and namespace as environment variables.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/KoalaOps/helm-charts/6?tool=ast&topic=Version+Bump>Version Bump</a>
        </td><td>Upgrades the Koala agent version from 1.0.5 to 1.0.6 across chart files.<details><summary>Modified files (2)</summary><ul><li>charts/koala-agent/Chart.yaml</li>
<li>charts/koala-agent/values.yaml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nadaverell</td><td>Bump-agent-helm-chart-...</td><td>June 05, 2024</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/KoalaOps/helm-charts/6?tool=ast&topic=Agent+Permissions>Agent Permissions</a>
        </td><td>Expands the agent's cluster role permissions to manage namespaces and adds pod identity information.<details><summary>Modified files (2)</summary><ul><li>charts/koala-agent/templates/deployment.yaml</li>
<li>charts/koala-agent/templates/clusterrole.yaml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nadaverell</td><td>Update-koala-agent-per...</td><td>August 15, 2023</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @nadaverell and the rest of your team on <a href=https://baz.co/changes/KoalaOps/helm-charts/6?tool=ast>(Baz)</a>.
    