### PR TITLE
Update clusterrole.yaml added certs permission

### DIFF
--- a/charts/koala-agent/Chart.yaml
+++ b/charts/koala-agent/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/koala-agent/templates/clusterrole.yaml
+++ b/charts/koala-agent/templates/clusterrole.yaml
@@ -133,7 +133,7 @@ rules:
     - get
     - watch
     - list
-  # Partial permissions for Cert Manager, excluding certificates
+  # Partial permissions for Cert Manager 
   - apiGroups:
     - cert-manager.io
     resources:
@@ -142,6 +142,7 @@ rules:
     - certificaterequests
     - challenges
     - orders
+    - certificates
     verbs:
     - get
     - watch


### PR DESCRIPTION
there is nothing secret about certs, with this permission we will be able to monitor the expiration etc...
example cert:
```
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  creationTimestamp: "2025-08-13T08:43:57Z"
  generation: 1
  labels:
    app.kubernetes.io/version: sessions-api_main_2025-08-11_00_01
  name: app-name-tls-cert
  namespace: production
  ownerReferences:
  - apiVersion: networking.k8s.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: Ingress
    name: sessions-api
    uid: 7fb4b4ff-549f-4905-af84-cef2b0c1b13b
  resourceVersion: "46530750"
  uid: c96e658c-1407-4ef8-9f01-5604b56539b4
spec:
  dnsNames:
  - host.com
  issuerRef:
    group: cert-manager.io
    kind: ClusterIssuer
    name: letsencrypt
  secretName: app-name-tls-cert
  usages:
  - digital signature
  - key encipherment
status:
  conditions:
  - lastTransitionTime: "2025-08-13T08:53:35Z"
    message: Certificate is up to date and has not expired
    observedGeneration: 1
    reason: Ready
    status: "True"
    type: Ready
  notAfter: "2025-11-11T07:55:04Z"
  notBefore: "2025-08-13T07:55:05Z"
  renewalTime: "2025-10-12T07:55:04Z"
  revision: 1
  ```